### PR TITLE
Mark untranslateable strings + additional Italian translation

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -74,4 +74,5 @@
         <item quantity="other">%d gruppi</item>
     </plurals>    <string name="faq_1_title">Voglio cambiare i campi visibili ai contatti. Come posso fare?</string>
     <string name="faq_1_text">Si può farlo andando in Impostazioni -&gt; Gestisci i campi mostrati. Qui si possono selezionare i campi che saranno visibili, alcuni sono disabilitati in maniera predefinita, quindi si possono trovare campi aggiuntivi.</string>
+    <string name="show_private_contacts">Mostra i contatti privati in Fossify Telefono, Fossify Messaggi SMS e Fossify Calendario</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="package_name">org.fossify.contacts</string>
+    <string name="package_name" translatable="false">org.fossify.contacts</string>
     <string name="app_name">Fossify Contacts</string>
 
-    <string name="im">IM</string>
-    <string name="aim">AIM</string>
-    <string name="windows_live">Windows Live</string>
-    <string name="yahoo">Yahoo</string>
-    <string name="skype">Skype</string>
-    <string name="qq">QQ</string>
-    <string name="hangouts">Hangouts</string>
-    <string name="icq">ICQ</string>
-    <string name="jabber">Jabber</string>
-    <string name="telegram">Telegram</string>
-    <string name="viber">Viber</string>
+    <string name="im" translatable="false">IM</string>
+    <string name="aim" translatable="false">AIM</string>
+    <string name="windows_live" translatable="false">Windows Live</string>
+    <string name="yahoo" translatable="false">Yahoo</string>
+    <string name="skype" translatable="false">Skype</string>
+    <string name="qq" translatable="false">QQ</string>
+    <string name="hangouts" translatable="false">Hangouts</string>
+    <string name="icq" translatable="false">ICQ</string>
+    <string name="jabber" translatable="false">Jabber</string>
+    <string name="telegram" translatable="false">Telegram</string>
+    <string name="viber" translatable="false">Viber</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [ ] Feature
- [X] Codebase improvement (translations)

#### Description of the changes in your PR
- **String not intended to be translated** in file `donottranslate.xml` marked with `translateable="false"`
Unclear to me why the app_name should not be translated in the local language.
- **Added missing Italian translation for for string `show_private_contacts`** (related to user setting).

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Contacts/blob/master/CONTRIBUTING.md).
