### PR TITLE
Fix delete logic in contact view if contact merging is disabled (new)

### DIFF
--- a/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
@@ -114,7 +114,7 @@ class ViewContactActivity : ContactActivity() {
             }
 
             findItem(R.id.delete).setOnMenuItemClickListener {
-                deleteContactFromAllSources()
+                deleteContactWithMergeLogic()
                 true
             }
 
@@ -838,8 +838,8 @@ class ViewContactActivity : ContactActivity() {
         }
     }
 
-    private fun deleteContactFromAllSources() {
-        val addition = if (binding.contactSourcesHolder.childCount > 1) {
+    private fun deleteContactWithMergeLogic() {
+        val addition = if (binding.contactSourcesHolder.childCount > 1 && mergeDuplicate) {
             "\n\n${getString(R.string.delete_from_all_sources)}"
         } else {
             ""
@@ -848,7 +848,7 @@ class ViewContactActivity : ContactActivity() {
         val message = "${getString(org.fossify.commons.R.string.proceed_with_deletion)}$addition"
         ConfirmationDialog(this, message) {
             if (contact != null) {
-                ContactsHelper(this).deleteContact(contact!!, true) {
+                ContactsHelper(this).deleteContact(contact!!, mergeDuplicate) {
                     finish()
                 }
             }

--- a/app/src/main/kotlin/org/fossify/contacts/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/adapters/ContactsAdapter.kt
@@ -224,13 +224,11 @@ class ContactsAdapter(
 
         ContactsHelper(activity).getContacts(true) { allContacts ->
             ensureBackgroundThread {
-                contactsToRemove.forEach {
-                    val contactToRemove = it
-                    val duplicates = allContacts.filter { it.id != contactToRemove.id && it.getHashToCompare() == contactToRemove.getHashToCompare() }
-                        .toMutableList() as ArrayList<Contact>
-                    duplicates.add(contactToRemove)
-                    ContactsHelper(activity).deleteContacts(duplicates)
-                }
+                ContactsHelper(activity).deleteContacts(contactsToRemove
+                    .flatMap { contactToRemove -> allContacts.filter {
+                        (config.mergeDuplicateContacts || it.id == contactToRemove.id) && (it.getHashToCompare() == contactToRemove.getHashToCompare())
+                    } }
+                    .toMutableList() as ArrayList<Contact>)
 
                 activity.runOnUiThread {
                     if (contactItems.isEmpty()) {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- If merging is disabled, only delete selected contact from contacts view.

#### Fixes the following issue(s)
- Fixes https://github.com/stephanritscher/Simple-Contacts/issues/4.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Contacts/blob/master/CONTRIBUTING.md).