### PR TITLE
Added Add to favorites button in groups (#152)

### DIFF
--- a/app/src/main/kotlin/org/fossify/contacts/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/adapters/ContactsAdapter.kt
@@ -98,7 +98,7 @@ class ContactsAdapter(
         menu.apply {
             findItem(R.id.cab_edit).isVisible = isOneItemSelected()
             findItem(R.id.cab_remove).isVisible = location == LOCATION_FAVORITES_TAB || location == LOCATION_GROUP_CONTACTS
-            findItem(R.id.cab_add_to_favorites).isVisible = location == LOCATION_CONTACTS_TAB
+            findItem(R.id.cab_add_to_favorites).isVisible = location == LOCATION_CONTACTS_TAB || location == LOCATION_GROUP_CONTACTS
             findItem(R.id.cab_add_to_group).isVisible = location == LOCATION_CONTACTS_TAB || location == LOCATION_FAVORITES_TAB
             findItem(R.id.cab_send_sms_to_contacts).isVisible =
                 location == LOCATION_CONTACTS_TAB || location == LOCATION_FAVORITES_TAB || location == LOCATION_GROUP_CONTACTS


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Added Add to favorites button in Groups tab.
    - I don't know why there was a code to specifically disable it in Groups tab. I've tested and everything works fine. I also searched through Simple Contacts history and haven't found anything why it wasn't enabled.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
![image](https://github.com/user-attachments/assets/21f75c58-e5b4-4b45-984b-5eacb22af19d)


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #152 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Contacts/blob/master/CONTRIBUTING.md).
