### PR TITLE
Ensure editing non-messenger contact while editing merged contact (#201)

### DIFF
--- a/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
@@ -2,14 +2,12 @@ package org.fossify.contacts.activities
 
 import android.content.ActivityNotFoundException
 import android.content.ContentUris
-import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Bundle
 import android.provider.ContactsContract
-import android.telephony.PhoneNumberUtils
 import android.view.View
 import android.view.WindowManager
 import android.widget.RelativeLayout
@@ -258,7 +256,7 @@ class ViewContactActivity : ContactActivity() {
             }
         }
 
-        getDuplicateContacts {
+        initializeDuplicateContacts {
             duplicateInitialized = true
             setupContactDetails()
         }
@@ -286,7 +284,7 @@ class ViewContactActivity : ContactActivity() {
     private fun launchEditContact(contact: Contact) {
         wasEditLaunched = true
         duplicateInitialized = false
-        editContact(contact)
+        editContact(contact, config.mergeDuplicateContacts)
     }
 
     private fun openWith() {
@@ -819,21 +817,11 @@ class ViewContactActivity : ContactActivity() {
         }
     }
 
-    private fun getDuplicateContacts(callback: () -> Unit) {
-        ContactsHelper(this).getDuplicatesOfContact(contact!!, false) { contacts ->
-            ensureBackgroundThread {
-                duplicateContacts.clear()
-                val displayContactSources = getVisibleContactSources()
-                contacts.filter { displayContactSources.contains(it.source) }.forEach {
-                    val duplicate = ContactsHelper(this).getContactWithId(it.id, it.isPrivate())
-                    if (duplicate != null) {
-                        duplicateContacts.add(duplicate)
-                    }
-                }
-
-                runOnUiThread {
-                    callback()
-                }
+    private fun initializeDuplicateContacts(callback: () -> Unit) {
+        getDuplicateContacts(contact!!) {
+            duplicateContacts = it
+            runOnUiThread {
+                callback()
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/contacts/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/adapters/ContactsAdapter.kt
@@ -192,7 +192,7 @@ class ContactsAdapter(
 
     private fun editContact() {
         val contact = getItemWithKey(selectedKeys.first()) ?: return
-        activity.editContact(contact)
+        activity.editContact(contact, config.mergeDuplicateContacts)
     }
 
     private fun askConfirmDelete() {

--- a/app/src/main/kotlin/org/fossify/contacts/extensions/Contact.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/extensions/Contact.kt
@@ -1,0 +1,12 @@
+package org.fossify.contacts.extensions
+
+import org.fossify.commons.helpers.*
+import org.fossify.commons.models.contacts.Contact
+import org.fossify.commons.models.contacts.ContactSource
+
+val messengerSources = hashSetOf(TELEGRAM_PACKAGE, SIGNAL_PACKAGE, WHATSAPP_PACKAGE, VIBER_PACKAGE, THREEMA_PACKAGE)
+
+fun Contact.isMessengerContact(contactSources: List<ContactSource>): Boolean {
+    val sourceData = contactSources.find { it.name == this.source }
+    return sourceData != null && messengerSources.contains(sourceData.type)
+}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Modified edit button (both in contacts list and viewing contact) to ensure it doesn't trigger editing messenger contact while having merging contacts turned on (as described in https://github.com/FossifyOrg/Contacts/issues/201#issuecomment-2569305543).
- To have common code for both places, I've moved finding duplicate contacts from `ViewContactActivity` to `Activity` extensions.
- As I couldn't reproduce the issue reported in #201, I've tested this feature by inverting conditions to always open the messenger contact. As it was working, I suppose that normal version of the code should also work.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #201

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Contacts/blob/master/CONTRIBUTING.md).
