### PR TITLE
fix: Primary Number indicator not visible with light theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed preferred number indicator not visible on white background
+
 ## [1.2.1] - 2025-06-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed preferred number indicator not visible on white background
+- Fixed invisible preferred number indicator in light themes ([#289])
 
 ## [1.2.1] - 2025-06-03
 
@@ -74,3 +74,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#30]: https://github.com/FossifyOrg/Contacts/issues/30
 [#201]: https://github.com/FossifyOrg/Contacts/issues/201
 [#281]: https://github.com/FossifyOrg/Contacts/issues/281
+[#289]: https://github.com/FossifyOrg/Contacts/issues/289

--- a/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
@@ -403,6 +403,10 @@ class ViewContactActivity : ContactActivity() {
                     }
 
                     defaultToggleIcon.isVisible = phoneNumber.isPrimary
+                    defaultToggleIcon.drawable?.apply {
+                        mutate()
+                        setTint(getProperTextColor())
+                    }
                 }
             }
             binding.contactNumbersImage.beVisible()

--- a/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/ViewContactActivity.kt
@@ -403,10 +403,7 @@ class ViewContactActivity : ContactActivity() {
                     }
 
                     defaultToggleIcon.isVisible = phoneNumber.isPrimary
-                    defaultToggleIcon.drawable?.apply {
-                        mutate()
-                        setTint(getProperTextColor())
-                    }
+                    defaultToggleIcon.applyColorFilter(getProperTextColor())
                 }
             }
             binding.contactNumbersImage.beVisible()


### PR DESCRIPTION
When the color scheme is set to use a white background color the star icon indicating the default number is drawn in white, making it invisible. The Edit activity explicitly sets the tint for the icon, do it for the View activity as well.

Fixes #289

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fixed preferred number star not visible in contact view when using a light color scheme / white background

#### Fixes the following issue(s)
- Fixes #289 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).
