### PR TITLE
fix: prevent silent discard of contact edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed contacts edits being silently discarded when using navigation arrow ([#360])
 
 ## [1.2.4] - 2025-07-31
 ### Changed
@@ -79,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#281]: https://github.com/FossifyOrg/Contacts/issues/281
 [#289]: https://github.com/FossifyOrg/Contacts/issues/289
 [#339]: https://github.com/FossifyOrg/Contacts/issues/339
+[#360]: https://github.com/FossifyOrg/Contacts/issues/360
 
 [Unreleased]: https://github.com/FossifyOrg/Contacts/compare/1.2.4...HEAD
 [1.2.4]: https://github.com/FossifyOrg/Contacts/compare/1.2.3...1.2.4

--- a/app/src/main/kotlin/org/fossify/contacts/activities/EditContactActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/EditContactActivity.kt
@@ -297,23 +297,29 @@ class EditContactActivity : ContactActivity() {
     }
 
     override fun onBackPressed() {
+        maybeShowUnsavedChangesDialog {
+            super.onBackPressed()
+        }
+    }
+
+    private fun maybeShowUnsavedChangesDialog(discard: () -> Unit) {
         if (System.currentTimeMillis() - mLastSavePromptTS > SAVE_DISCARD_PROMPT_INTERVAL && hasContactChanged()) {
             mLastSavePromptTS = System.currentTimeMillis()
             ConfirmationAdvancedDialog(
-                this,
-                "",
-                org.fossify.commons.R.string.save_before_closing,
-                org.fossify.commons.R.string.save,
-                org.fossify.commons.R.string.discard
+                activity = this,
+                message = "",
+                messageId = org.fossify.commons.R.string.save_before_closing,
+                positive = org.fossify.commons.R.string.save,
+                negative = org.fossify.commons.R.string.discard
             ) {
                 if (it) {
                     saveContact()
                 } else {
-                    super.onBackPressed()
+                    discard()
                 }
             }
         } else {
-            super.onBackPressed()
+            discard()
         }
     }
 
@@ -360,8 +366,9 @@ class EditContactActivity : ContactActivity() {
         }
 
         binding.contactToolbar.setNavigationOnClickListener {
-            hideKeyboard()
-            finish()
+            maybeShowUnsavedChangesDialog {
+                finish()
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/contacts/activities/EditContactActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/EditContactActivity.kt
@@ -367,6 +367,7 @@ class EditContactActivity : ContactActivity() {
 
         binding.contactToolbar.setNavigationOnClickListener {
             maybeShowUnsavedChangesDialog {
+                hideKeyboard()
                 finish()
             }
         }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Applied the same checks as `onBackPressed()` before finishing the activity in the navigation click listener callback.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Contacts/issues/360

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
