### PR TITLE
feat: Enable contact import via Android Share Sheet

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,10 +48,18 @@
             android:exported="false"
             android:theme="@style/SplashTheme" />
 
+        <!--
+            Allows this activity to receive temporary access grants for URIs passed in an Intent.
+            When an external app (like the default Contacts app) shares a file, it does so
+            via a secure content:// URI and adds FLAG_GRANT_READ_URI_PERMISSION to the Intent.
+            This attribute is required to prevent a SecurityException, ensuring we can
+            read the content (e.g., a vCard file) shared by another application.
+        -->
         <activity
             android:name=".activities.MainActivity"
             android:configChanges="orientation"
-            android:exported="true">
+            android:exported="true"
+            android:grantUriPermissions="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -59,6 +67,15 @@
                 <data android:mimeType="text/directory" />
                 <data android:mimeType="text/vcard" />
                 <data android:mimeType="text/x-vcard" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+
+                <data android:mimeType="text/x-vcard" />
+                <data android:mimeType="text/vcard" />
 
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- `AndroidManifest.xml`: Registered the app as a share target for contacts via an <intent-filter>. to make the app appear in the Android Share Sheet.
- Add `grantUriPermissions` to securely accept temporary read permission from other apps. Otherwise app'll get `SecurityException`
- Intent Handling: Added logic to parse `ACTION_VIEW`, `SEND`, and `SEND_MULTIPLE` intents  to handle single, multiple, and direct file opening scenarios.
- File Handling: Processed shared contact URIs on a background thread to prevent UI freezes to keep the UI responsive and prevent the app from freezing.


#### Tests performed

- Manually tested sharing a single contact from the default Android Contacts app. The app appeared in the share sheet and successfully imported the contact.
- Manually tested sharing multiple contacts. The app correctly handled the list of contacts.
- Tested by opening a .vcf file directly from a file manager. The app opened and processed the file.


#### Before 
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/f9d599c8-59d4-4f46-a5ea-c54d0c9df20c" width=180 />

### After
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/a5834d5e-cd0a-492a-9b92-5b45ef56d980" width=180 />


#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #321 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
