### PR TITLE
Fix: Import FN field from vCard 4.0 when N field is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed import of vCard 4.0 contacts with only FN field ([#465])
 
 ## [1.6.0] - 2026-01-30
 ### Added

--- a/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
@@ -55,9 +55,18 @@ class VcfImporter(val activity: SimpleActivity) {
             for (ezContact in ezContacts) {
                 val structuredName = ezContact.structuredName
                 val prefix = structuredName?.prefixes?.firstOrNull() ?: ""
-                val firstName = structuredName?.given ?: ""
-                val middleName = structuredName?.additionalNames?.firstOrNull() ?: ""
-                val surname = structuredName?.family ?: ""
+                var firstName = structuredName?.given ?: ""
+                var middleName = structuredName?.additionalNames?.firstOrNull() ?: ""
+                var surname = structuredName?.family ?: ""
+
+                if (structuredName == null && ezContact.formattedName?.value?.isNotBlank() == true) {
+                    val fn = ezContact.formattedName.value.trim()
+                    val parts = fn.split("\\s+".toRegex(), limit = 2)
+
+                    firstName = parts.getOrNull(0) ?: ""
+                    surname = parts.getOrNull(1) ?: ""
+                }
+
                 val suffix = structuredName?.suffixes?.firstOrNull() ?: ""
                 val nickname = ezContact.nickname?.values?.firstOrNull() ?: ""
                 var photoUri = ""
@@ -267,16 +276,6 @@ class VcfImporter(val activity: SimpleActivity) {
                     mimetype = DEFAULT_MIMETYPE,
                     ringtone = ringtone
                 )
-
-                // if there is no N and ORG fields at the given contact, only FN, treat it as an organization
-                if (
-                    contact.getNameToDisplay().isEmpty()
-                    && contact.organization.isEmpty()
-                    && ezContact.formattedName?.value?.isNotEmpty() == true
-                ) {
-                    contact.organization.company = ezContact.formattedName.value
-                    contact.mimetype = CommonDataKinds.Organization.CONTENT_ITEM_TYPE
-                }
 
                 if (contact.isABusinessContact()) {
                     contact.mimetype = CommonDataKinds.Organization.CONTENT_ITEM_TYPE

--- a/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
@@ -67,10 +67,11 @@ class VcfImporter(val activity: SimpleActivity) {
                 // firstName instead of guessing a given/family split, which
                 // would silently corrupt names like "von Neumann" or non-Western
                 // name orders.
+                val hasStructuredName = firstName.isNotBlank()
+                    || middleName.isNotBlank()
+                    || surname.isNotBlank()
                 val formattedName = ezContact.formattedName?.value?.trim().orEmpty()
-                if (firstName.isBlank() && middleName.isBlank() && surname.isBlank()
-                    && formattedName.isNotBlank()
-                ) {
+                if (!hasStructuredName && formattedName.isNotBlank()) {
                     firstName = formattedName
                 }
 

--- a/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
@@ -56,18 +56,24 @@ class VcfImporter(val activity: SimpleActivity) {
                 val structuredName = ezContact.structuredName
                 val prefix = structuredName?.prefixes?.firstOrNull() ?: ""
                 var firstName = structuredName?.given ?: ""
-                var middleName = structuredName?.additionalNames?.firstOrNull() ?: ""
-                var surname = structuredName?.family ?: ""
+                val middleName = structuredName?.additionalNames?.firstOrNull() ?: ""
+                val surname = structuredName?.family ?: ""
+                val suffix = structuredName?.suffixes?.firstOrNull() ?: ""
 
-                if (structuredName == null && ezContact.formattedName?.value?.isNotBlank() == true) {
-                    val fn = ezContact.formattedName.value.trim()
-                    val parts = fn.split("\\s+".toRegex(), limit = 2)
-
-                    firstName = parts.getOrNull(0) ?: ""
-                    surname = parts.getOrNull(1) ?: ""
+                // vCard 4.0 makes the structured name (N) optional while the
+                // formatted name (FN) is mandatory. When N is missing or yields
+                // no usable parts, fall back to FN. FN is a free-form display
+                // string with no guaranteed word order, so we keep it intact in
+                // firstName instead of guessing a given/family split, which
+                // would silently corrupt names like "von Neumann" or non-Western
+                // name orders.
+                val formattedName = ezContact.formattedName?.value?.trim().orEmpty()
+                if (firstName.isBlank() && middleName.isBlank() && surname.isBlank()
+                    && formattedName.isNotBlank()
+                ) {
+                    firstName = formattedName
                 }
 
-                val suffix = structuredName?.suffixes?.firstOrNull() ?: ""
                 val nickname = ezContact.nickname?.values?.firstOrNull() ?: ""
                 var photoUri = ""
 


### PR DESCRIPTION
- Remove incorrect logic that treated FN as organization name
- Use FN field directly as contact name when N field is absent
- Fixes #465

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
In vCard 4.0, FN is required but N is optional. Previously, contacts
with only FN field were incorrectly imported as organizations with
email addresses shown as the contact name.

#### Tests performed
I have successfully imported the three vCards which I will attach to this PR on my S22

#### Closes the following issue(s)
- Closes #465 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
