### PR TITLE
fix: sanitize custom IM type label before using as IMPP URI scheme

### DIFF
--- a/app/src/main/kotlin/org/fossify/contacts/helpers/VcfExporter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/helpers/VcfExporter.kt
@@ -156,7 +156,17 @@ class VcfExporter {
                         Im.PROTOCOL_GOOGLE_TALK -> Impp(HANGOUTS, it.value)
                         Im.PROTOCOL_QQ -> Impp(QQ, it.value)
                         Im.PROTOCOL_JABBER -> Impp(JABBER, it.value)
-                        else -> Impp(it.label, it.value)
+                        else -> {
+                            // IMPP URIs use the label as the URI scheme, which only allows
+                            // [a-zA-Z][a-zA-Z0-9+-.]*. Replace any character outside that
+                            // set with a hyphen so labels containing spaces (or other symbols)
+                            // don't throw an IllegalArgumentException and corrupt the export.
+                            val scheme = it.label
+                                .replace(Regex("[^a-zA-Z0-9+\\-.]"), "-")
+                                .let { s -> if (s.firstOrNull()?.isLetter() != true) "x-$s" else s }
+                                .ifEmpty { "x-custom" }
+                            Impp(scheme, it.value)
+                        }
                     }
 
                     card.addImpp(impp)

--- a/app/src/main/kotlin/org/fossify/contacts/helpers/VcfExporter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/helpers/VcfExporter.kt
@@ -163,8 +163,13 @@ class VcfExporter {
                             // don't throw an IllegalArgumentException and corrupt the export.
                             val scheme = it.label
                                 .replace(Regex("[^a-zA-Z0-9+\\-.]"), "-")
-                                .let { s -> if (s.firstOrNull()?.isLetter() != true) "x-$s" else s }
-                                .ifEmpty { "x-custom" }
+                                .let { s ->
+                                    when {
+                                        s.isEmpty() -> "x-custom"
+                                        s.firstOrNull()?.isLetter() != true -> "x-$s"
+                                        else -> s
+                                    }
+                                }
                             Impp(scheme, it.value)
                         }
                     }


### PR DESCRIPTION
## What

Fixes #499

A contact with a custom IM type containing a space (e.g. `"a b"`) caused sharing/export to fail silently — a 0-byte file was written and an error toast appeared.

## Root cause

`VcfExporter` passes `it.label` directly as the *protocol* argument to ez-vcard's `Impp(String protocol, String handle)` constructor. That constructor builds a `java.net.URI` using the protocol string as the URI scheme. URI schemes only allow `[a-zA-Z][a-zA-Z0-9+-.]*`, so a label containing a space throws `IllegalArgumentException`, which propagates up and aborts the export.

## Fix

Before constructing the `Impp` property, replace any character outside the valid URI-scheme set with a hyphen. Two additional guards:

- Labels that start with a non-letter are prefixed with `"x-"` (scheme must begin with `ALPHA`)
- Empty labels fall back to `"x-custom"`

## Testing

Manually verified:
1. Create a contact, set IM field to custom type `"a b"` with a username.
2. Before fix: **Export → 0-byte file, error toast.**
3. After fix: **Export succeeds**, IMPP line written as `IMPP:a-b:username`.

Compiled and linted against `fossDebug` variant — no errors or new warnings.

## Note on round-trip fidelity

Labels with spaces will be stored as hyphen-separated strings in the exported VCF (e.g. `"a b"` → `"a-b"`). Preserving the original label through the URI scheme is not possible without a larger structural change (URI schemes forbid percent-encoding). This is a known limitation documented in the code comment.