### PR TITLE
MainActivity: auto-refresh on system contact changes (ContentObserver)

### DIFF
--- a/app/src/main/kotlin/org/fossify/contacts/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/MainActivity.kt
@@ -41,6 +41,10 @@ import org.fossify.contacts.interfaces.RefreshContactsListener
 import java.util.Arrays
 
 class MainActivity : SimpleActivity(), RefreshContactsListener {
+    companion object {
+        private const val CONTACT_REFRESH_DEBOUNCE_MS = 500L
+    }
+
     private var werePermissionsHandled = false
     private var isFirstResume = true
     private var isGettingContacts = false
@@ -177,7 +181,7 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
         val observer = object : ContentObserver(contactObserverHandler) {
             override fun onChange(selfChange: Boolean) {
                 contactObserverHandler.removeCallbacks(contactReloadRunnable)
-                contactObserverHandler.postDelayed(contactReloadRunnable, 500)
+                contactObserverHandler.postDelayed(contactReloadRunnable, CONTACT_REFRESH_DEBOUNCE_MS)
             }
         }
         runCatching {

--- a/app/src/main/kotlin/org/fossify/contacts/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/activities/MainActivity.kt
@@ -4,10 +4,14 @@ import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.ShortcutInfo
+import android.database.ContentObserver
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Icon
 import android.graphics.drawable.LayerDrawable
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.provider.ContactsContract
 import androidx.viewpager.widget.ViewPager
 import me.grantland.widget.AutofitHelper
 import org.fossify.commons.databases.ContactsDatabase
@@ -143,12 +147,14 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
 
         isFirstResume = false
         checkShortcuts()
+        registerContactObserver()
     }
 
     override fun onPause() {
         super.onPause()
         storeStateVariables()
         config.lastUsedViewPagerPage = binding.viewPager.currentItem
+        unregisterContactObserver()
     }
 
     override fun onDestroy() {
@@ -156,6 +162,38 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
         if (!isChangingConfigurations) {
             ContactsDatabase.destroyInstance()
         }
+    }
+
+    private val contactObserverHandler = Handler(Looper.getMainLooper())
+    private val contactReloadRunnable = Runnable {
+        if (werePermissionsHandled) {
+            refreshContacts(ALL_TABS_MASK)
+        }
+    }
+    private var contactObserver: ContentObserver? = null
+
+    private fun registerContactObserver() {
+        unregisterContactObserver()
+        val observer = object : ContentObserver(contactObserverHandler) {
+            override fun onChange(selfChange: Boolean) {
+                contactObserverHandler.removeCallbacks(contactReloadRunnable)
+                contactObserverHandler.postDelayed(contactReloadRunnable, 500)
+            }
+        }
+        runCatching {
+            contentResolver.registerContentObserver(
+                ContactsContract.Contacts.CONTENT_URI, true, observer
+            )
+            contactObserver = observer
+        }
+    }
+
+    private fun unregisterContactObserver() {
+        contactObserverHandler.removeCallbacks(contactReloadRunnable)
+        contactObserver?.let { observer ->
+            runCatching { contentResolver.unregisterContentObserver(observer) }
+        }
+        contactObserver = null
     }
 
     override fun onBackPressedCompat(): Boolean {


### PR DESCRIPTION
## Problem

When a contact is added, edited, or deleted by another app — system contact picker, a sync adapter (Google/Nextcloud/etc.), CSV importer, or any third-party tool that writes to `ContactsContract.Contacts` — Fossify Contacts currently only re-reads the contact list on the next `onResume()`. If the user is already on the contact list while the change happens, the stale list stays on screen until they manually navigate away and back.

## Fix

Register a `ContentObserver` on `ContactsContract.Contacts.CONTENT_URI` in `onResume()`, unregister in `onPause()`. When the observer fires, call `refreshContacts(ALL_TABS_MASK)` debounced by 500 ms so a bulk row-by-row update (e.g., a sync of 200 contacts) coalesces into a single refresh rather than firing 200 times.

## Files touched

- `app/src/main/kotlin/org/fossify/contacts/activities/MainActivity.kt` (+38)

## Lifecycle correctness

- Observer is registered only while the activity is in the resumed state.
- `onPause()` always unregisters before the activity becomes paused — no observer leaks across configuration changes or process death.
- `runCatching` wraps both register and unregister to swallow the rare `IllegalStateException` from the framework when the resolver state is invalid (Android 11 occasionally throws on rapid pause/resume cycles).
- 500 ms debounce uses the existing main-thread handler — no new threads.

## Tested

Manual: open Fossify Contacts → keep it foreground → from a separate app (`adb shell content insert`) add and delete contacts → list refreshes within ~500 ms each time without user input.

## Notes

If you'd prefer a different debounce window or want this gated behind a preference, happy to adjust.