### PR TITLE
fix: trim vCard name fields on import to fix mis-sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed contacts imported from vCard files being mis-sorted (filed after "Z") when their name fields contained leading or trailing whitespace ([#195])
 
 ## [1.6.0] - 2026-01-30
 ### Added
@@ -119,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#30]: https://github.com/FossifyOrg/Contacts/issues/30
 [#78]: https://github.com/FossifyOrg/Contacts/issues/78
 [#157]: https://github.com/FossifyOrg/Contacts/issues/157
+[#195]: https://github.com/FossifyOrg/Contacts/issues/195
 [#201]: https://github.com/FossifyOrg/Contacts/issues/201
 [#281]: https://github.com/FossifyOrg/Contacts/issues/281
 [#289]: https://github.com/FossifyOrg/Contacts/issues/289

--- a/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/helpers/VcfImporter.kt
@@ -54,12 +54,12 @@ class VcfImporter(val activity: SimpleActivity) {
             val ezContacts = Ezvcard.parse(inputStream).all()
             for (ezContact in ezContacts) {
                 val structuredName = ezContact.structuredName
-                val prefix = structuredName?.prefixes?.firstOrNull() ?: ""
-                val firstName = structuredName?.given ?: ""
-                val middleName = structuredName?.additionalNames?.firstOrNull() ?: ""
-                val surname = structuredName?.family ?: ""
-                val suffix = structuredName?.suffixes?.firstOrNull() ?: ""
-                val nickname = ezContact.nickname?.values?.firstOrNull() ?: ""
+                val prefix = structuredName?.prefixes?.firstOrNull()?.trim() ?: ""
+                val firstName = structuredName?.given?.trim() ?: ""
+                val middleName = structuredName?.additionalNames?.firstOrNull()?.trim() ?: ""
+                val surname = structuredName?.family?.trim() ?: ""
+                val suffix = structuredName?.suffixes?.firstOrNull()?.trim() ?: ""
+                val nickname = ezContact.nickname?.values?.firstOrNull()?.trim() ?: ""
                 var photoUri = ""
 
                 val phoneNumbers = ArrayList<PhoneNumber>()


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
`VcfImporter` stored the structured-name components (`given`, `family`, `additionalNames`, `prefixes`, `suffixes`) and the nickname verbatim from ezvcard, without trimming. A vCard whose given-name field has a leading space (e.g. `N:Doe; John;;;`) was therefore imported as `firstName = " John"`.

That corrupts the sort key: `Contact.compareTo` builds it with `firstName.normalizeString()`, and `normalizeString()` only strips diacritics via NFD normalization, not whitespace. `compareUsingStrings` then deterministically orders any value whose first character is not a letter (a leading space; `' '.isLetter() == false`) after every A-Z name, so the contact files at the very end, after "Z". The contact still *displays* as "John" because `getNameToDisplay()` trims, which is exactly the confusing symptom the reporter described. The fast-scroll bubble (`getBubbleText()`, which returns the raw first name) is affected too.

The contact editor already trims these fields when saving, through the commons `EditText.value` extension (`text.toString().trim()`). This change makes VCF import match that convention by applying `?.trim()` to each structured-name component at import time. For a null component the safe-call short-circuits and the elvis yields `""`, so behavior is unchanged for absent fields; for `" John"` it yields `"John"`. One place fixes sorting, the fast-scroll bubble, and business-contact detection.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Imported a vCard whose given name had a leading space (' John'); sorted by First name. 'John Doe' filed correctly under 'J' between 'Amy Adams' and 'Zack Zulu', avatar shows 'J', fast-scroll index shows A/J/Z (no blank / bottom placement). Name trimmed on import.

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #195

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
