### PR TITLE
feat: remember last used contact source when importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Contact import now remembers the last used contact source ([#81])
 
 ## [1.6.0] - 2026-01-30
 ### Added
@@ -118,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#12]: https://github.com/FossifyOrg/Contacts/issues/12
 [#30]: https://github.com/FossifyOrg/Contacts/issues/30
 [#78]: https://github.com/FossifyOrg/Contacts/issues/78
+[#81]: https://github.com/FossifyOrg/Contacts/issues/81
 [#157]: https://github.com/FossifyOrg/Contacts/issues/157
 [#201]: https://github.com/FossifyOrg/Contacts/issues/201
 [#281]: https://github.com/FossifyOrg/Contacts/issues/281

--- a/app/src/main/kotlin/org/fossify/contacts/dialogs/ImportContactsDialog.kt
+++ b/app/src/main/kotlin/org/fossify/contacts/dialogs/ImportContactsDialog.kt
@@ -61,6 +61,7 @@ class ImportContactsDialog(val activity: SimpleActivity, val path: String, priva
 
                         ignoreClicks = true
                         activity.toast(org.fossify.commons.R.string.importing)
+                        activity.config.lastUsedContactSource = targetContactSource
                         ensureBackgroundThread {
                             val result = VcfImporter(activity).importContacts(path, targetContactSource)
                             handleParseResult(result)


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
The import dialog already defaulted to the last used contact source but never stored the selection, so it kept falling back to whatever was set elsewhere.

Note: `lastUsedContactSource` is shared with the new-contact screen, so an import now also updates the default account there. This is consistent with the pref's existing "last used" meaning, but it does touch the behaviour discussed in #9.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Last used source is persisted in same session
 - Last used source is persisted when restarting the app

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on open issues labeled **help wanted**, except for the documented exceptions. -->

- Closes #81 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
